### PR TITLE
fix to handle same code in multiple transactions

### DIFF
--- a/lib/health-data-standards/export/helper/cat1_view_helper.rb
+++ b/lib/health-data-standards/export/helper/cat1_view_helper.rb
@@ -28,7 +28,17 @@ module HealthDataStandards
             # If there's an error exporting particular criteria, re-raise an error that includes useful debugging info
             begin
               entries = entries_for_data_criteria(udc['data_criteria'], patient)
-              render_entries = (entries - tempEntries)
+              render_entries=[]
+              for entry in entries
+                if ([entry] - tempEntries).length > 0
+                  render_entries.push(entry)
+                else
+                  existingEntry = tempEntries.select{|e| e==entry}[0]
+                  if not existingEntry.to_json == entry.to_json
+                    render_entries.push(entry)
+                  end
+                end
+              end
               if render_entries.length > 0
                 tempEntries.concat(render_entries)
                 render_data_criteria(udc, render_entries, r2_compatibility, qrda_version)


### PR DESCRIPTION
Pull requests into Health Data Standards require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.
 
**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] This PR is into the correct branch.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links back to this PR
- [ ] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass
- [ ] Code coverage has not gone down and all code touched or added is covered.
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here:
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here:
 
**Cypress Reviewer:**
 
Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
 
**Bonnie Reviewer:**
 
Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
